### PR TITLE
docs(how-to): Add context to Contributing #23

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,15 @@ delivery using GitHub actions.
 Contributing
 ------------
 
-See our :ref:`Code of Conduct <code-of-conduct>`.
+Contributions are very welcome and appreciated!
 
+You can contribute in many ways.
 
-See our :ref:`Contributing How-To <contribute-how-to>`.
+See our `Contributing How-To
+<https://django-cookiecutter.readthedocs.io/en/latest/how-tos/
+how-to-contribute.html#contribute-how-to>`_ to help you get started.
+
+Please take a moment to read our `Code of Conduct
+<https://django-cookiecutter.readthedocs.io/en/latest/
+code-of-conduct.html#code-of-conduct>`_ for how we would like our community
+to treat each other.

--- a/docs/source/code-of-conduct.rst
+++ b/docs/source/code-of-conduct.rst
@@ -24,7 +24,7 @@ diverse, inclusive, and healthy community.
 Our Standards
 -------------
 
-Examples of behavior that contributes to a positive environment for our
+Examples of behaviour that contributes to a positive environment for our
 community include:
 
 * Demonstrating empathy and kindness toward other people
@@ -35,7 +35,7 @@ community include:
 * Focusing on what is best not just for us as individuals, but for the
   overall community
 
-Examples of unacceptable behavior include:
+Examples of unacceptable behaviour include:
 
 * The use of sexualized language or imagery, and sexual attention or
   advances of any kind
@@ -50,8 +50,8 @@ Enforcement Responsibilities
 ----------------------------
 
 Community leaders are responsible for clarifying and enforcing our standards of
-acceptable behavior and will take appropriate and fair corrective action in
-response to any behavior that they deem inappropriate, threatening, offensive,
+acceptable behaviour and will take appropriate and fair corrective action in
+response to any behaviour that they deem inappropriate, threatening, offensive,
 or harmful.
 
 Community leaders have the right and responsibility to remove, edit, or reject
@@ -62,16 +62,16 @@ decisions when appropriate.
 Scope
 -----
 
-This Code of Conduct applies within all community spaces, and also applies when
+This Code of Conduct applies within all community spaces and also applies when
 an individual is officially representing the community in public spaces.
-Examples of representing our community include using an official e-mail address,
+Examples of representing our community include using an official email address,
 posting via an official social media account, or acting as an appointed
 representative at an online or offline event.
 
 Enforcement
 -----------
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be
 reported to the community leaders responsible for enforcement at
 mark.sevelj@dunwright.com.au.
 All complaints will be reviewed and investigated promptly and fairly.
@@ -87,31 +87,31 @@ the consequences for any action they deem in violation of this Code of Conduct:
 
 1. Correction
 
-**Community Impact**: Use of inappropriate language or other behavior deemed
+**Community Impact**: Use of inappropriate language or other behaviour deemed
 unprofessional or unwelcome in the community.
 
-**Consequence**: A private, written warning from community leaders, providing
-clarity around the nature of the violation and an explanation of why the
-behavior was inappropriate. A public apology may be requested.
+**Consequence**: A private, written warning from community leaders, clarifying
+the nature of the violation and explaining why the behaviour was inappropriate.
+Community leaders may request a public apology.
 
 2. Warning
 
 **Community Impact**: A violation through a single incident or series
 of actions.
 
-**Consequence**: A warning with consequences for continued behavior. No
+**Consequence**: A warning with consequences for continued behaviour. No
 interaction with the people involved, including unsolicited interaction with
-those enforcing the Code of Conduct, for a specified period of time. This
-includes avoiding interactions in community spaces as well as external channels
+those enforcing the Code of Conduct, for a specified period of time.
+Uninvited interactions include community spaces as well as external channels
 like social media. Violating these terms may lead to a temporary or
 permanent ban.
 
 3. Temporary Ban
 
 **Community Impact**: A serious violation of community standards, including
-sustained inappropriate behavior.
+sustained inappropriate behaviour.
 
-**Consequence**: A temporary ban from any sort of interaction or public
+**Consequence**: A temporary ban from any interaction or public
 communication with the community for a specified period of time. No public or
 private interaction with the people involved, including unsolicited interaction
 with those enforcing the Code of Conduct, is allowed during this period.
@@ -120,19 +120,19 @@ Violating these terms may lead to a permanent ban.
 4. Permanent Ban
 
 **Community Impact**: Demonstrating a pattern of violation of community
-standards, including sustained inappropriate behavior,  harassment of an
+standards, including sustained inappropriate behaviour,  harassment of an
 individual, or aggression toward or disparagement of classes of individuals.
 
-**Consequence**: A permanent ban from any sort of public interaction within
+**Consequence**: A permanent ban from any public interaction within
 the community.
 
 Attribution
 -----------
 
-This Code of Conduct is adapted from the `Contributor Covenant
+This Code of Conduct adapted from the `Contributor Covenant
 version 2.0 <https://www.contributor-covenant.org/version/2/0/code_of_conduct.html>`_.
 
-Also see `Contributor Covenant homepage <https://www.contributor-covenant.org>`_.
+Also, see `Contributor Covenant homepage <https://www.contributor-covenant.org>`_.
 
 For answers to common questions about this code of conduct, see the
 `FAQ <https://www.contributor-covenant.org/faq>`_.

--- a/docs/source/how-tos/how-to-contribute.rst
+++ b/docs/source/how-tos/how-to-contribute.rst
@@ -112,6 +112,31 @@ pass code quality checks.
 The docstring should convey `what` is done, not `how` it is done to your
 users for clarity and consistency.
 
+See the `amazing_new_feature.py` example below.
+
+.. code-block:: python
+    :linenos:
+
+    """Classes for adding Amazing New Features."""
+
+    class AmazingNewFeaturesFromOld:
+        """A class of making old features new again."""
+
+        def amazing_new_feature_from_old_1(self):
+            """Take some old feature and make it fresh again."""
+
+        def amazing_new_feature_from_old_2(self):
+            """Take another old feature and make it fresher."""
+
+    class AmazingNewFeatures:
+        """A class of making brand new features."""
+
+        def amazing_new_feature_1(self):
+            """Improve user experience feature one."""
+
+        def amazing_new_feature_2(self):
+            """Improve user experience feature two."""
+
 
 Submit Feedback
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
Missing docstring example, so this was included.
Also README links to Contributing and CoC fixed.
Fixed typo's in Code of Conduct.

closes #23