### PR TITLE
docs(git): Add Conventional Commits msg template #33

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -10,7 +10,7 @@
   "add_contributors_list": "n",
   "version": "0.1.0",
 
-  "create_conventional_commits_edit_message": "y",
+  "create_conventional_commits_edit_message": ["y", "n"],
   "create_repo_auto_test_workflow": "y",
   "use_GH_action_semantic_version": "y",
   "use_pre_commit": "y",

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -126,8 +126,8 @@ if __name__ == "__main__":
     # if "Not open source" == "{{ cookiecutter.open_source_license }}":
     #     remove_file("LICENSE")
 
-    # if "{{ cookiecutter.create_conventional_commits_edit_message }}" != "y":
-    #     remove_file(".github/.git-commit-template.txt")
+    if "{{ cookiecutter.create_conventional_commits_edit_message }}" == "n":
+        remove_file(".github/.git-commit-template.txt")
 
     # if "{{ cookiecutter.create_repo_auto_test_workflow }}" != "y":
     #     remove_file(".github/workflows/test_contribution.yaml")

--- a/tests/test_bake_django.py
+++ b/tests/test_bake_django.py
@@ -4,8 +4,7 @@ import os
 
 
 def test_django_bakes_ok_with_defaults(cookies):
-    """Test cookiecutter created the django project ok."""
-
+    """Test cookiecutter created the Django project ok."""
     default_django = cookies.bake()
 
     assert default_django.project_path.is_dir()
@@ -15,8 +14,7 @@ def test_django_bakes_ok_with_defaults(cookies):
 
 
 def test_baked_django_asgi_file(cookies):
-    """Test Django asgy.py file has generated correctly."""
-
+    """Test Django asgy.py file has been generated correctly."""
     default_django = cookies.bake()
 
     asgi_path = default_django.project_path / "django_boilerplate/asgi.py"
@@ -29,9 +27,35 @@ def test_baked_django_asgi_file(cookies):
     )
 
 
+def test_baked_django_with_commit_message_file(cookies):
+    """Test Django Conventional commit message template has been generated correctly."""
+
+    default_django = cookies.bake()
+
+    commit_msg_path = default_django.project_path / ".github/.git-commit-template.txt"
+    commit_msg_file = commit_msg_path.read_text().splitlines()
+
+    assert ".git-commit-template.txt" in os.listdir(
+        (default_django.project_path / ".github")
+    )
+
+
+def test_baked_django_without_commit_message_file(cookies):
+    """Test Django Conventional commit message template has not been generated."""
+
+    non_default_django = cookies.bake(
+        extra_context={
+            "create_conventional_commits_edit_message": "n",
+        }
+    )
+
+    assert ".git-commit-template.txt" not in os.listdir(
+        (non_default_django.project_path / ".github")
+    )
+
+
 def test_baked_django_settings_file(cookies):
     """Test Django settings.py file has generated correctly."""
-
     default_django = cookies.bake()
 
     settings_path = default_django.project_path / "django_boilerplate/settings.py"
@@ -51,15 +75,12 @@ def test_baked_django_settings_file(cookies):
 
 def test_baked_django_urls_file(cookies):
     """Test Django urls.py file has generated correctly."""
-
     default_django = cookies.bake()
 
     urls_path = default_django.project_path / "django_boilerplate/urls.py"
     urls_file = urls_path.read_text().splitlines()
 
     assert '"""django-boilerplate URL Configuration' in urls_file
-    # assert 'DEBUG = "False"' in settings_file
-    # assert 'DEBUG = "False"' in settings_file
 
 
 def test_baked_django_with_custom_issue_template_files(cookies):
@@ -69,7 +90,6 @@ def test_baked_django_with_custom_issue_template_files(cookies):
     generated correctly, and post_gen deleted the standard template.
 
     """
-
     default_django = cookies.bake()
 
     bug_path = default_django.project_path / ".github/ISSUE_TEMPLATE/bug-report.md"
@@ -105,22 +125,22 @@ def test_baked_django_without_custom_issue_template_files(cookies):
     generated correctly, and post-gen deleted the Custom Issue templates.
 
     """
+    non_default_django = cookies.bake(
+        extra_context={"use_GH_custom_issue_templates": "n"}
+    )
 
-    default_django = cookies.bake(extra_context={"use_GH_custom_issue_templates": "n"})
-
-    standard_issue_path = default_django.project_path / ".github/ISSUE_TEMPLATE.md"
+    standard_issue_path = non_default_django.project_path / ".github/ISSUE_TEMPLATE.md"
     standard_issue_file = standard_issue_path.read_text().splitlines()
 
     assert '- "django-boilerplate" version:' in standard_issue_file
 
-    ISSUE_TEMPLATE_parent = default_django.project_path / ".github"
+    ISSUE_TEMPLATE_parent = non_default_django.project_path / ".github"
     dir_list = os.listdir((ISSUE_TEMPLATE_parent))
     assert "ISSUE_TEMPLATE" not in dir_list
 
 
 def test_baked_django_wsgi_file(cookies):
     """Test Django asgi.py file has generated correctly."""
-
     default_django = cookies.bake()
 
     wsgi_path = default_django.project_path / "django_boilerplate/wsgi.py"

--- a/{{cookiecutter.git_project_name}}/.github/.git-commit-template.txt
+++ b/{{cookiecutter.git_project_name}}/.github/.git-commit-template.txt
@@ -1,0 +1,44 @@
+
+# tag(subject):<Description>  #nn being the issue number if it exists
+# (subject): CHANGELOG update groups items with the same subject.
+# |<----   Preferably using up to 50 chars   --->|<--Max of 72 chars-->|
+# Example: docs(style):Added a new reST style guide #42
+
+
+# (Optional) Explain why this change is being made
+# |<----   Try To Limit Each Line to a Maximum Of 72 Characters   ---->|
+# Example: There wasnt a reST style guide.
+
+
+# (Optional) Provide links or keys to any relevant tickets, articles or other resources
+# Example: closes #42
+
+
+# --- COMMIT END ---
+# Tags with ** will be included in the CHANGELOG
+# **   chore    (a chore that needs to be done)
+#      dbg      (changes in debugging code/frameworks; no production code change)
+#      defaults (changes default options)
+# **   docs      (changes to documentation)
+# **   feat     (new feature)
+# **   fix      (bug fix)
+#      hack     (temporary fix to make things move forward; please avoid it)
+#      license  (edits regarding licensing; no production code change)
+# **   perf     (performance improvement)
+# **   refactor (refactoring code)
+# **   style    (formatting, missing semi colons, etc; no code change)
+# **   test     (adding or refactoring tests; no production code change)
+#      version  (version bump/new release; no production code change)
+#      WIP      (Work In Progress; for intermediate commits to keep patches reasonably sized)
+#      jsrXXX   (patches related to the implementation of jsrXXX, where XXX the JSR number)
+#      jdkX     (patches related to supporting jdkX as the host VM, where X the JDK version)
+#
+# --------------------
+# Remember to:
+#   * Capitalize the subject line start
+#   * Use the imperative mood in the subject line
+#   * Do not end the subject line with a period
+#   * Separate subject from body with a blank line
+#   * Use the body to explain what and why vs. how
+#   * Can use multiple lines with "-" or "*" for bullet points in body
+# --------------------


### PR DESCRIPTION
Assists users in providing the information required in a consistent
format when making git commits.  The Conventional Commits format is
necessary for python semantic versioning to work correctly.

closes #33