### PR TITLE
docs(django): Add select a license option #37

### DIFF
--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -1,4 +1,7 @@
+.. cookie_license::
+====================
 BSD 3-Clause License
+====================
 
 Copyright (c) 2021, mark sevelj
 All rights reserved.

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -122,8 +122,8 @@ def remove_file(filepath):
 
 if __name__ == "__main__":
 
-    # if "Not open source" == "{{ cookiecutter.open_source_license }}":
-    #     remove_file("LICENSE")
+    if "{{ cookiecutter.open_source_license }}" == "Not open source":
+        remove_file("LICENSE.rst")
 
     if "{{ cookiecutter.create_conventional_commits_edit_message }}" == "n":
         remove_file(".github/.git-commit-template.txt")

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -1,5 +1,4 @@
-"""
-django-cookiecutter pre package generation jobs.
+"""django-cookiecutter pre package generation jobs.
 
 .. todo::
 

--- a/tests/test_bake_django.py
+++ b/tests/test_bake_django.py
@@ -1,5 +1,6 @@
 """django-cookiecutter test suite."""
 
+import datetime
 import os
 
 
@@ -47,8 +48,7 @@ def test_baked_django_without_commit_message_file(cookies):
 
 
 def test_baked_django_with_custom_issue_template_files(cookies):
-    """
-    Test Django project has custom ISSUE templates generated correctly.
+    """Test Django project has custom ISSUE templates generated correctly.
 
     Tests that the Custom Issue templates have had the "assignee"
     generated correctly, and post_gen deleted the standard template.
@@ -112,12 +112,119 @@ def test_baked_django_init_file(cookies):
     assert '"""Initialise django_boilerplate."""' in init_file
 
 
+def test_baked_django_with_mit_license(cookies):
+    """Test Django MIT license file has been generated correctly."""
+    default_django = cookies.bake(
+        extra_context={
+            "open_source_license": "MIT license",
+        }
+    )
+
+    lic_path = default_django.project_path / "LICENSE.rst"
+    lic_file = lic_path.read_text().splitlines()
+
+    assert "MIT License" in lic_file
+    assert f"Copyright (c) {datetime.datetime.now().year}, Mark Sevelj" in lic_file
+
+    assert "Apache Software License 2.0" not in lic_file
+    assert "BSD License" not in lic_file
+    assert "GNU GENERAL PUBLIC LICENSE" not in lic_file
+    assert "ISC License" not in lic_file
+
+
+def test_baked_django_with_bsd_license(cookies):
+    """Test Django BSD license file has been generated correctly."""
+    non_default_django = cookies.bake(
+        extra_context={
+            "open_source_license": "BSD license",
+        }
+    )
+
+    lic_path = non_default_django.project_path / "LICENSE.rst"
+    lic_file = lic_path.read_text().splitlines()
+
+    assert "BSD License" in lic_file
+    assert f"Copyright (c) {datetime.datetime.now().year}, Mark Sevelj" in lic_file
+
+    assert "Apache Software License 2.0" not in lic_file
+    assert "GNU GENERAL PUBLIC LICENSE" not in lic_file
+    assert "ISC License" not in lic_file
+    assert "MIT License" not in lic_file
+
+
+def test_baked_django_with_isc_license(cookies):
+    """Test Django ISC license file has been generated correctly."""
+    non_default_django = cookies.bake(
+        extra_context={
+            "open_source_license": "ISC license",
+        }
+    )
+
+    lic_path = non_default_django.project_path / "LICENSE.rst"
+    lic_file = lic_path.read_text().splitlines()
+
+    assert "ISC License" in lic_file
+    assert f"Copyright (c) {datetime.datetime.now().year}, Mark Sevelj" in lic_file
+
+    assert "Apache Software License 2.0" not in lic_file
+    assert "BSD License" not in lic_file
+    assert "GNU GENERAL PUBLIC LICENSE" not in lic_file
+    assert "MIT License" not in lic_file
+
+
+def test_baked_django_with_apache_license(cookies):
+    """Test Django Apache Software License 2.0 license file has been generated correctly."""
+    non_default_django = cookies.bake(
+        extra_context={
+            "open_source_license": "Apache Software License 2.0",
+        }
+    )
+
+    lic_path = non_default_django.project_path / "LICENSE.rst"
+    lic_file = lic_path.read_text().splitlines()
+
+    assert "Apache Software License 2.0" in lic_file
+    assert f"Copyright (c) {datetime.datetime.now().year}, Mark Sevelj" in lic_file
+
+    assert "BSD License" not in lic_file
+    assert "ISC License" not in lic_file
+    assert "GNU GENERAL PUBLIC LICENSE" not in lic_file
+    assert "MIT License" not in lic_file
+
+
+def test_baked_django_with_gnu_license(cookies):
+    """Test Django GNU General Public License v3 license file has been generated correctly."""
+    non_default_django = cookies.bake(
+        extra_context={
+            "open_source_license": "GNU General Public License v3",
+        }
+    )
+
+    lic_path = non_default_django.project_path / "LICENSE.rst"
+    lic_file = lic_path.read_text().splitlines()
+
+    assert "GNU GENERAL PUBLIC LICENSE" in lic_file
+    assert f"    Copyright (C) {datetime.datetime.now().year}  Mark Sevelj" in lic_file
+
+    assert "MIT License" not in lic_file
+    assert "Apache Software License 2.0" not in lic_file
+    assert "BSD License" not in lic_file
+    assert "ISC License" not in lic_file
+
+
+def test_baked_django_without_license(cookies):
+    """Test Django  has been generated without a license file."""
+    non_default_django = cookies.bake(
+        extra_context={
+            "open_source_license": "Not open source",
+        }
+    )
+    assert "LICENSE.rst" not in os.listdir((non_default_django.project_path))
+
+
 def test_baked_django_with_precommit_config_file(cookies):
     """Test Django pre-commit has been generated correctly."""
     default_django = cookies.bake()
-
-    commit_msg_path = default_django.project_path / ".github/.git-commit-template.txt"
-    commit_msg_file = commit_msg_path.read_text().splitlines()
 
     assert ".pre-commit-config.yaml" in os.listdir((default_django.project_path))
 

--- a/tox.ini
+++ b/tox.ini
@@ -37,3 +37,6 @@ deps =
     -r{toxinidir}/requirements_dev.txt
 commands =
     pytest  -v {posargs:tests}
+
+[pydocstyle]
+ignore = D213

--- a/{{cookiecutter.git_project_name}}/LICENSE.rst
+++ b/{{cookiecutter.git_project_name}}/LICENSE.rst
@@ -1,0 +1,133 @@
+{% if cookiecutter.open_source_license == 'MIT license' -%}
+.. _mit-license:
+===========
+MIT License
+===========
+
+Copyright (c) {% now 'local', '%Y' %}, {{ cookiecutter.author_name }}
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+{% elif cookiecutter.open_source_license == 'BSD license' %}
+.. _bsd-license:
+===========
+BSD License
+===========
+
+Copyright (c) {% now 'local', '%Y' %}, {{ cookiecutter.author_name }}
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from this
+  software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCEOR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISEDOF THE POSSIBILITY OF SUCH DAMAGE.
+{% elif cookiecutter.open_source_license == 'ISC license' -%}
+.. _isc-license:
+===========
+ISC License
+===========
+
+Copyright (c) {% now 'local', '%Y' %}, {{ cookiecutter.author_name }}
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+{% elif cookiecutter.open_source_license == 'Apache Software License 2.0' -%}
+.. _apache-license:
+===========================
+Apache Software License 2.0
+===========================
+
+Copyright (c) {% now 'local', '%Y' %}, {{ cookiecutter.author_name }}
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+{% elif cookiecutter.open_source_license == 'GNU General Public License v3' -%}
+.. _gnu-license:
+==========================
+GNU GENERAL PUBLIC LICENSE
+==========================
+                      Version 3, 29 June 2007
+
+    {{ cookiecutter.project_short_description }}
+    Copyright (C) {% now 'local', '%Y' %}  {{ cookiecutter.author_name }}
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<http://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<http://www.gnu.org/philosophy/why-not-lgpl.html>.
+{% endif %}


### PR DESCRIPTION
Five options for LICENSE selection are now available to the user.

closes #37