### PR TITLE
feat(django): Add Read the Docs config and badge #43

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,9 +11,9 @@ delivery using GitHub actions.
 .. _Django: https://www.djangoproject.com/
 .. _cookiecutter: https://github.com/cookiecutter/cookiecutter
 
-.. image:: https://www.repostatus.org/badges/latest/concept.svg
-   :alt: Project Status: Concept – Minimal or no implementation has been done yet, or the repository is only intended to be a limited example, demo, or proof-of-concept.
-   :target: https://www.repostatus.org/#concept
+.. image:: https://www.repostatus.org/badges/latest/wip.svg
+   :alt: Project Status: WIP – Initial development is in progress, but there has not yet been a stable, usable release suitable for the public.
+   :target: https://www.repostatus.org/#wip
 
 .. image:: https://app.codacy.com/project/badge/Grade/87fb6c8ef02d4433b87e483a9a926d62
    :alt: Codacy Quality
@@ -38,7 +38,7 @@ Django Project Options
    #. A `Copy Button`_ to assist your users copy.
    #. `Inline Tabs`_ to group similar items.
    #. Use markdown or restructured text.
-
+#. Deploy to `Read the Docs`_.
 #. A documentation framework with templates using the
    `Diátaxis framework <https://junction-box.readthedocs.io/en/latest/Document-Framework/diataxis-intro.html>`_.
 #. A Pre-generated Contributing How-to. Edit to suit your needs.
@@ -54,6 +54,7 @@ Django Project Options
 .. _Furo: https://github.com/pradyunsg/furo
 .. _Copy Button: https://sphinx-copybutton.readthedocs.io/en/latest/
 .. _Inline Tabs: https://sphinx-inline-tabs.readthedocs.io/en/latest/
+.. _Read the Docs: https://readthedocs.org/
 
 Contributing
 ------------

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -13,6 +13,7 @@
   "use_pre_commit": ["y", "n"],
 
   "include_sphinx_docs": ["y", "n"],
+  "use_readthedocs": ["y", "n"],
   "include_documentation_templates":["y", "n"],
   "include_how_to_contribute_template":["y", "n"],
   "include_contributor_covenant_code_of_conduct":["y", "n"],

--- a/docs/source/readme.rst
+++ b/docs/source/readme.rst
@@ -1,0 +1,1 @@
+.. include:: ../../README.rst

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -161,6 +161,9 @@ if __name__ == "__main__":
     ):
         remove_file("docs/source/code-of-conduct.rst")
 
+    if "{{ cookiecutter.use_readthedocs }}" == "n":
+        remove_file(".readthedocs.yaml")
+
     # if "{{ cookiecutter.automatic_set_up_git_and_initial_commit }}" == "y":
     #     init_git()
     #     git_add_and_commit_initial()

--- a/tests/test_bake_django.py
+++ b/tests/test_bake_django.py
@@ -238,6 +238,50 @@ def test_baked_django_docs_how_to_index(cookies):
     assert "See below for a list of How-To for Django Boilerplate." in index_file
 
 
+def test_baked_django_with_read_the_docs(cookies):
+    """Test Django readthedocs config has been generated correctly."""
+    default_django = cookies.bake()
+
+    assert ".readthedocs.yaml" in os.listdir((default_django.project_path))
+
+    rtd_path = default_django.project_path / "README.rst"
+    rtd_file = rtd_path.read_text().splitlines()
+
+    assert (
+        ".. image:: https://readthedocs.org/projects/django-boilerplate/badge/?version=latest"
+        in rtd_file
+    )
+    assert (
+        "   :target: https://django-boilerplate.readthedocs.io/en/latest/?badge=latest"
+        in rtd_file
+    )
+    assert "   :alt: Documentation Status" in rtd_file
+
+
+def test_baked_django_without_read_the_docs(cookies):
+    """Test Django readthedocs config has not been generated correctly."""
+    non_default_django = cookies.bake(
+        extra_context={
+            "use_readthedocs": "n",
+        }
+    )
+
+    assert ".readthedocs.yaml" not in os.listdir((non_default_django.project_path))
+
+    rtd_path = non_default_django.project_path / "README.rst"
+    rtd_file = rtd_path.read_text().splitlines()
+
+    assert (
+        ".. image:: https://readthedocs.org/projects/django-boilerplate/badge/?version=latest"
+        not in rtd_file
+    )
+    assert (
+        "   :target: https://django-boilerplate.readthedocs.io/en/latest/?badge=latest"
+        not in rtd_file
+    )
+    assert "   :alt: Documentation Status" not in rtd_file
+
+
 def test_baked_django_docs_references_index(cookies):
     """Test Django docs reference index template file has been generated correctly."""
     default_django = cookies.bake()

--- a/{{cookiecutter.git_project_name}}/.readthedocs.yaml
+++ b/{{cookiecutter.git_project_name}}/.readthedocs.yaml
@@ -1,0 +1,16 @@
+version: 2
+
+build:
+    image: testing
+
+sphinx:
+    builder: html
+    configuration: docs/source/conf.py
+    # fail_on_warning: true
+
+python:
+    version: "3.9"
+    install:
+        - requirements: docs/requirements.txt
+        - method: pip
+          path: .

--- a/{{cookiecutter.git_project_name}}/README.rst
+++ b/{{cookiecutter.git_project_name}}/README.rst
@@ -16,6 +16,12 @@
    :alt: pre-commit
 {%- endif %}
 
+{%- if cookiecutter.use_readthedocs == "y" %}
+.. image:: https://readthedocs.org/projects/{{cookiecutter.git_project_name}}/badge/?version=latest
+   :target: https://{{cookiecutter.git_project_name}}.readthedocs.io/en/latest/?badge=latest
+   :alt: Documentation Status
+{%- endif %}
+
 {%- if cookiecutter.open_source_license != "Not open source" %}
 :License: {{cookiecutter.open_source_license}}
 {%- endif %}


### PR DESCRIPTION
Read the Docs is a standard document deployment service.

closes #43