### PR TITLE
feat(django): Add semantic-release GH action #45

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,10 @@ delivery using GitHub actions.
    :alt: Documentation Status
 
 
+.. image:: https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg
+   :target: https://python-semantic-release.readthedocs.io/en/latest/
+   :alt: Python Sementic Release
+
 Django Project Options
 ----------------------
 
@@ -50,6 +54,7 @@ Django Project Options
 #. Choose from three
    `Repository Status Badges <https://www.repostatus.org/#concept>`_.
    Quickly communicate to potential users.
+#. A Python Semantic Release GitHub action.
 
 .. _Furo: https://github.com/pradyunsg/furo
 .. _Copy Button: https://sphinx-copybutton.readthedocs.io/en/latest/

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -20,7 +20,7 @@
 
   "create_conventional_commits_edit_message": ["y", "n"],
   "create_repo_auto_test_workflow": "y",
-  "use_GH_action_semantic_version": "y",
+  "use_GH_action_semantic_version": ["y", "n"],
   "use_GH_custom_issue_templates": ["y", "n"],
   "automatic_set_up_git_and_initial_commit": "y",
   "open_source_license": ["MIT license", "BSD license", "ISC license", "Apache Software License 2.0", "GNU General Public License v3", "Not open source"],
@@ -33,6 +33,13 @@
   "TIME_ZONE": "UTC",
   "USE_L10N": "True",
   "USE_I18N": "True",
-  "SITE_ID": "1"
+  "SITE_ID": "1",
+
+  "_copy_without_render": [
+        ".pre-commit-config.yaml",
+        ".github/workflows/semantic_release.yaml",
+        ".github/workflows/semantic_release_test_pypi.yaml",
+        ".github/workflows/test_contribution.yaml"
+    ]
 
 }

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -115,7 +115,7 @@ def recursive_force_delete_a_folder(folder_path):
 
 
 def remove_file(filepath):
-    """Remove files not required for this generated python package."""
+    """Remove files not required for this generated Django project."""
     if os.path.exists(os.path.join(PROJECT_DIRECTORY, filepath)):
         os.remove(os.path.join(PROJECT_DIRECTORY, filepath))
 
@@ -131,12 +131,10 @@ if __name__ == "__main__":
     # if "{{ cookiecutter.create_repo_auto_test_workflow }}" != "y":
     #     remove_file(".github/workflows/test_contribution.yaml")
 
-    # if "{{ cookiecutter.use_GH_action_semantic_version }}" != "y":
-    #     remove_file(".github/workflows/semantic_release.yaml")
-    #     remove_file(".github/semantic.yaml")
-
-    # if "{{ cookiecutter.use_GH_action_semantic_version }}" == "y":
-    #     remove_file("HISTORY.rst")
+    if "{{ cookiecutter.use_GH_action_semantic_version }}" != "y":
+        remove_file("CHANGELOG.md")
+        remove_file(".github/semantic.yaml")
+        remove_file(".github/workflows/semantic_release.yaml")
 
     if "{{ cookiecutter.use_GH_custom_issue_templates }}" == "y":
         remove_file(".github/ISSUE_TEMPLATE.md")

--- a/tests/test_bake_django.py
+++ b/tests/test_bake_django.py
@@ -297,6 +297,58 @@ def test_baked_django_docs_references_index(cookies):
     )
 
 
+def test_baked_django_with_semantic_release(cookies):
+    """Test Django semantic-release file has been generated correctly."""
+    default_django = cookies.bake()
+
+    assert "CHANGELOG.md" in os.listdir((default_django.project_path))
+    assert "semantic.yaml" in os.listdir((default_django.project_path / ".github"))
+    assert "semantic_release.yaml" in os.listdir(
+        (default_django.project_path / ".github/workflows")
+    )
+
+    readme_path = default_django.project_path / "README.rst"
+    readme_file = readme_path.read_text().splitlines()
+
+    assert (
+        ".. image:: https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg"
+        in readme_file
+    )
+    assert (
+        "   :target: https://python-semantic-release.readthedocs.io/en/latest/"
+        in readme_file
+    )
+    assert "   :alt: Python Sementic Release" in readme_file
+
+
+def test_baked_django_without_semantic_release(cookies):
+    """Test Django semantic-release file has not been generated."""
+    non_default_django = cookies.bake(
+        extra_context={"use_GH_action_semantic_version": "n"}
+    )
+
+    assert "CHANGELOG.md" not in os.listdir((non_default_django.project_path))
+    assert "semantic.yaml" not in os.listdir(
+        (non_default_django.project_path / ".github")
+    )
+    assert "semantic_release.yaml" not in os.listdir(
+        (non_default_django.project_path / ".github/workflows")
+    )
+
+    readme_path = non_default_django.project_path / "README.rst"
+    readme_file = readme_path.read_text().splitlines()
+
+    assert (
+        ".. image:: https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg"
+        not in readme_file
+    )
+    assert (
+        "   :target: https://python-semantic-release.readthedocs.io/en/latest/"
+        not in readme_file
+    )
+    assert "   :alt: Python Sementic Release" not in readme_file
+
+
 def test_baked_django_docs_templates_index(cookies):
     """Test Django docs index template file has been generated correctly."""
     default_django = cookies.bake()
@@ -516,7 +568,7 @@ def test_baked_django_readme_with_repostatus_badge(cookies):
         ".. image:: https://www.repostatus.org/badges/latest/concept.svg" in readme_file
     )
     assert "   :target: https://www.repostatus.org/#concept" in readme_file
-    assert "   :alt: Project Status: Concept" in readme_file
+    assert "   :alt: Project Status: concept" in readme_file
 
 
 def test_baked_django_readme_without_repostatus_badge(cookies):

--- a/{{cookiecutter.git_project_name}}/.github/semantic.yaml
+++ b/{{cookiecutter.git_project_name}}/.github/semantic.yaml
@@ -1,0 +1,32 @@
+# Always validate the PR title AND all the commits
+titleAndCommits: true
+
+# A list of valid scopes
+# scopes:
+#     - CHANGELOG
+#     - scope2
+
+# Allow use of Merge commits (eg on github: "Merge branch 'master'
+# into feature/ride-unicorns").
+# this is only relevant when using commitsOnly: true (or titleAndCommits: true)
+allowMergeCommits: true
+
+# Allow use of Revert commits (eg on github: "Revert "feat: ride unicorns"")
+# this is only relevant when using commitsOnly: true (or titleAndCommits: true)
+allowRevertCommits: true
+
+# By default types specified in commitizen/conventional-commit-types is used.
+# See: https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json
+# You can override the valid types
+types:
+  - build
+  - chore
+  - ci
+  - docs
+  - feat
+  - fix
+  - perf
+  - refactor
+  - revert
+  - style
+  - test

--- a/{{cookiecutter.git_project_name}}/.github/workflows/semantic_release.yaml
+++ b/{{cookiecutter.git_project_name}}/.github/workflows/semantic_release.yaml
@@ -1,0 +1,28 @@
+name: Semantic Release
+
+on:
+  pull_request:
+    branches:
+      - main
+    types: [closed]
+
+  workflow_dispatch:
+
+concurrency:
+  group: Semantic Release
+
+jobs:
+  release:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.SEM_VER }}
+          fetch-depth: 0
+
+      - name: Python Semantic Release
+        uses: relekang/python-semantic-release@master
+        with:
+          github_token: ${{ secrets.SEM_VER }}

--- a/{{cookiecutter.git_project_name}}/CHANGELOG.md
+++ b/{{cookiecutter.git_project_name}}/CHANGELOG.md
@@ -1,0 +1,3 @@
+# CHANGELOG
+
+<!--next-version-placeholder-->

--- a/{{cookiecutter.git_project_name}}/README.rst
+++ b/{{cookiecutter.git_project_name}}/README.rst
@@ -6,14 +6,20 @@
 
 {%- if cookiecutter.use_repo_status_badge != "no" %}
 .. image:: https://www.repostatus.org/badges/latest/{{cookiecutter.use_repo_status_badge}}.svg
-   :target: https://www.repostatus.org/#concept
-   :alt: Project Status: Concept
+   :target: https://www.repostatus.org/#{{cookiecutter.use_repo_status_badge}}
+   :alt: Project Status: {{cookiecutter.use_repo_status_badge}}
 {%- endif %}
 
 {%- if cookiecutter.use_pre_commit == "y" %}
 .. image:: https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white
    :target: https://github.com/pre-commit/pre-commit
    :alt: pre-commit
+{%- endif %}
+
+{%- if cookiecutter.use_GH_action_semantic_version == "y" %}
+.. image:: https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg
+   :target: https://python-semantic-release.readthedocs.io/en/latest/
+   :alt: Python Sementic Release
 {%- endif %}
 
 {%- if cookiecutter.use_readthedocs == "y" %}


### PR DESCRIPTION
Using semantic-release as a GitHub action removes possible
release inconsistencies.

closes #45