### PR TITLE
feat(cookie): Add pyup checks and badge #53

### DIFF
--- a/.pyup.yaml
+++ b/.pyup.yaml
@@ -1,0 +1,34 @@
+# configure updates globally
+# default: all
+# allowed: all, insecure, False
+update: all
+
+# configure dependency pinning globally
+# default: True
+# allowed: True, False
+pin: True
+
+# set the default branch
+# default: empty, the default branch on GitHub
+Default Branch: main
+
+# assign users to pull requests, default is not set
+# requires private repo permissions, even on public repos
+# default: empty
+assignees:
+  - imAsparky
+
+# add a label to pull requests, default is not set
+# requires private repo permissions, even on public repos
+# default: empty
+label_prs: "fix(pyup): Update dependencies"
+
+# allow to close stale PRs
+# default: True
+close_prs: False
+
+requirements:
+  - "requirements_dev.txt"
+  - "docs/requirements.txt"
+  - "{{cookiecutter.git_project_name}}/requirements_dev.txt"
+  - "{{cookiecutter.git_project_name}}/docs/requirements.txt"

--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,10 @@ delivery using GitHub actions.
    :alt: Codacy Quality
    :target: https://www.codacy.com/gh/imAsparky/django-cookiecutter/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=imAsparky/django-cookiecutter&amp;utm_campaign=Badge_Grade
 
+.. image:: https://pyup.io/repos/github/imAsparky/django-cookiecutter/shield.svg
+     :target: https://pyup.io/repos/github/imAsparky/django-cookiecutter/
+     :alt: Updates
+
 .. image:: https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white
    :target: https://github.com/pre-commit/pre-commit
    :alt: pre-commit

--- a/{{cookiecutter.git_project_name}}/requirements_dev.txt
+++ b/{{cookiecutter.git_project_name}}/requirements_dev.txt
@@ -1,0 +1,11 @@
+Django==3.2.7
+
+# Documentation
+
+furo==2021.8.17b43
+myst-parser==0.15.1
+pre-commit==2.15.0
+pytest==6.2.5
+pytest-cookies==0.6.1
+Sphinx==4.1.2
+tox==3.24.4


### PR DESCRIPTION
Keep dependencies up to date, pyup uses Conventional commits now.

closes #53