### PR TITLE
fix(django): Remove duplicate tox dependency #108

### DIFF
--- a/{{cookiecutter.git_project_name}}/config/requirements/test.txt
+++ b/{{cookiecutter.git_project_name}}/config/requirements/test.txt
@@ -1,3 +1,3 @@
 pytest==6.2.5
 pytest-cookies==0.6.1
-tox==3.24.4tox==3.24.4
+tox==3.24.4


### PR DESCRIPTION
Two tox dependencies in Django config/requirements/test.txt had
concatenated.

closes #108