### PR TITLE
chore(django): Remove pytest-cookies from test deps #112

### DIFF
--- a/{{cookiecutter.git_project_name}}/config/requirements/test.txt
+++ b/{{cookiecutter.git_project_name}}/config/requirements/test.txt
@@ -1,3 +1,2 @@
 pytest==6.2.5
-pytest-cookies==0.6.1
 tox==3.24.4


### PR DESCRIPTION
pytest-cookies is not required for django.

closes #112