### PR TITLE
chore(django): Add django-debug-toolbar panels #123

### DIFF
--- a/{{cookiecutter.git_project_name}}/config/settings/local.py
+++ b/{{cookiecutter.git_project_name}}/config/settings/local.py
@@ -9,6 +9,8 @@ DEBUG = True
 # https://docs.djangoproject.com/en/dev/ref/settings/#allowed-hosts
 ALLOWED_HOSTS = ["localhost", "0.0.0.0", "127.0.0.1"]
 
+INTERNAL_IPS = ["127.0.0.1", "10.0.2.2"]
+
 
 # django-debug-toolbar
 # https://django-debug-toolbar.readthedocs.io/en/latest/installation.html
@@ -19,14 +21,24 @@ INSTALLED_APPS += ["debug_toolbar", "template_profiler_panel"]  # noqa F405
 
 MIDDLEWARE += ["debug_toolbar.middleware.DebugToolbarMiddleware"]  # noqa F405
 
+DEBUG_TOOLBAR_PANELS = [
+    "debug_toolbar.panels.history.HistoryPanel",
+    "debug_toolbar.panels.versions.VersionsPanel",
+    "debug_toolbar.panels.timer.TimerPanel",
+    "debug_toolbar.panels.settings.SettingsPanel",
+    "debug_toolbar.panels.headers.HeadersPanel",
+    "debug_toolbar.panels.request.RequestPanel",
+    "debug_toolbar.panels.sql.SQLPanel",
+    "debug_toolbar.panels.staticfiles.StaticFilesPanel",
+    "debug_toolbar.panels.templates.TemplatesPanel",
+    "debug_toolbar.panels.cache.CachePanel",
+    "debug_toolbar.panels.signals.SignalsPanel",
+    "debug_toolbar.panels.logging.LoggingPanel",
+    "debug_toolbar.panels.redirects.RedirectsPanel",
+    "debug_toolbar.panels.profiling.ProfilingPanel",
+    "template_profiler_panel.panels.template.TemplateProfilerPanel",
+]
 
 DEBUG_TOOLBAR_CONFIG = {
     "DISABLE_PANELS": ["debug_toolbar.panels.redirects.RedirectsPanel"],
 }
-
-DEBUG_TOOLBAR_PANELS = [
-    # ...
-    "template_profiler_panel.panels.template.TemplateProfilerPanel",
-]
-
-INTERNAL_IPS = ["127.0.0.1", "10.0.2.2"]


### PR DESCRIPTION
debug toolbar is missing some panels, add all the panels to the list
so template_profiler does not overwrite them.

closes #123