### PR TITLE
fix(django): Fix typo for install pytest-django #126

### DIFF
--- a/{{cookiecutter.git_project_name}}/config/requirements/test.txt
+++ b/{{cookiecutter.git_project_name}}/config/requirements/test.txt
@@ -1,6 +1,6 @@
 dj-inmemorystorage==2.1.0
 pytest==6.2.5
-pytest-django-4.4.0
+pytest-django==4.4.0
 pytest-reverse==1.3.0
 pytest-xdist==2.4.0
 tblib==1.7.0


### PR DESCRIPTION
Test requirements had a typo for the version number pinning.

closes #126