### PR TITLE
fix(deps): Django 4.0 ugetext update to gettext #181

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 ===========================
-**Django 3.2 Cookiecutter**
+**Django 4.0 Cookiecutter**
 ===========================
 
 **Version 1.0 will signify the first stable Django build!**

--- a/{{cookiecutter.git_project_name}}/config/settings/base.py
+++ b/{{cookiecutter.git_project_name}}/config/settings/base.py
@@ -11,7 +11,7 @@ https://docs.djangoproject.com/en/3.2/ref/settings/
 
 from pathlib import Path
 import os
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from .username_blacklist import data as username_blacklist
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.


### PR DESCRIPTION
fix(deps): Django 4.0 ugetext update to gettext #181

Features removed in 4.0¶

These features have reached the end of their deprecation cycle and are
removed in Django 4.0.
django.utils.translation.ugettext(), ugettext_lazy(), ugettext_noop(),
ungettext(), and ungettext_lazy()

closes #181