### PR TITLE
fix(deps): Debug toolbar disabled until update #191

### DIFF
--- a/{{cookiecutter.git_project_name}}/config/settings/local.py
+++ b/{{cookiecutter.git_project_name}}/config/settings/local.py
@@ -27,31 +27,34 @@ EMAIL_BACKEND = env("EMAIL_BACKEND")
 # https://django-debug-toolbar.readthedocs.io/en/latest/installation.html
 # https://github.com/node13h/django-debug-toolbar-template-profiler
 
-INSTALLED_APPS += ["debug_toolbar", "template_profiler_panel"]  # noqa F405
+# Django 4.0 does not support ugettext_lazy any more.
+# Debug toolbar still requires ugettext_lazy.  Disabled until it runs on 4.0
 
-MIDDLEWARE += ["debug_toolbar.middleware.DebugToolbarMiddleware"]  # noqa F405
+# INSTALLED_APPS += ["debug_toolbar", "template_profiler_panel"]  # noqa F405
 
-DEBUG_TOOLBAR_PANELS = [
-    "debug_toolbar.panels.history.HistoryPanel",
-    "debug_toolbar.panels.versions.VersionsPanel",
-    "debug_toolbar.panels.timer.TimerPanel",
-    "debug_toolbar.panels.settings.SettingsPanel",
-    "debug_toolbar.panels.headers.HeadersPanel",
-    "debug_toolbar.panels.request.RequestPanel",
-    "debug_toolbar.panels.sql.SQLPanel",
-    "debug_toolbar.panels.staticfiles.StaticFilesPanel",
-    "debug_toolbar.panels.templates.TemplatesPanel",
-    "debug_toolbar.panels.cache.CachePanel",
-    "debug_toolbar.panels.signals.SignalsPanel",
-    "debug_toolbar.panels.logging.LoggingPanel",
-    "debug_toolbar.panels.redirects.RedirectsPanel",
-    "debug_toolbar.panels.profiling.ProfilingPanel",
-    "template_profiler_panel.panels.template.TemplateProfilerPanel",
-]
+# MIDDLEWARE += ["debug_toolbar.middleware.DebugToolbarMiddleware"]  # noqa F405
 
-DEBUG_TOOLBAR_CONFIG = {
-    "DISABLE_PANELS": ["debug_toolbar.panels.redirects.RedirectsPanel"],
-}
+# DEBUG_TOOLBAR_PANELS = [
+#     "debug_toolbar.panels.history.HistoryPanel",
+#     "debug_toolbar.panels.versions.VersionsPanel",
+#     "debug_toolbar.panels.timer.TimerPanel",
+#     "debug_toolbar.panels.settings.SettingsPanel",
+#     "debug_toolbar.panels.headers.HeadersPanel",
+#     "debug_toolbar.panels.request.RequestPanel",
+#     "debug_toolbar.panels.sql.SQLPanel",
+#     "debug_toolbar.panels.staticfiles.StaticFilesPanel",
+#     "debug_toolbar.panels.templates.TemplatesPanel",
+#     "debug_toolbar.panels.cache.CachePanel",
+#     "debug_toolbar.panels.signals.SignalsPanel",
+#     "debug_toolbar.panels.logging.LoggingPanel",
+#     "debug_toolbar.panels.redirects.RedirectsPanel",
+#     "debug_toolbar.panels.profiling.ProfilingPanel",
+#     "template_profiler_panel.panels.template.TemplateProfilerPanel",
+# ]
+
+# DEBUG_TOOLBAR_CONFIG = {
+#     "DISABLE_PANELS": ["debug_toolbar.panels.redirects.RedirectsPanel"],
+# }
 
 DATABASES = {
     "default": {


### PR DESCRIPTION
Django debug-toolbar requires ugettext_lazy.  Django 4.0 does not
support that anymore.  Debug toolbar is disabled in
config/settings/local.py until it runs on Django 4.0.

closes #191