### PR TITLE
fix(options): Remove L10N choice from set-up #183

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -13,10 +13,6 @@
   "LANGUAGE_CODE": "en",
   "LANGUAGES": "en, hi",
   "TIME_ZONE": "UTC",
-  "USE_L10N": [
-    "True",
-    "False"
-  ],
   "USE_I18N": [
     "True",
     "False"

--- a/tests/test_bake_django.py
+++ b/tests/test_bake_django.py
@@ -842,7 +842,6 @@ def test_baked_django_base_settings_base_file_ok(cookies):
     assert "    ('en', _(\"English\"))," in settings_file
     assert 'TIME_ZONE = "UTC"' in settings_file
     assert "USE_I18N = True" in settings_file
-    assert "USE_L10N = True" in settings_file
 
 
 def test_baked_django_settings_local_file_ok(cookies):

--- a/{{cookiecutter.git_project_name}}/config/settings/base.py
+++ b/{{cookiecutter.git_project_name}}/config/settings/base.py
@@ -119,12 +119,6 @@ AUTH_PASSWORD_VALIDATORS = [
     "es": "Spanish",
 }) %}
 {% if cookiecutter.USE_I18N == "True" %}
-{% if cookiecutter.USE_L10N == "True" %}
-USE_L10N = True
-{% else %}
-# Dperacated in 4.0
-USE_L10N = False
-{% endif %}
 USE_I18N = True
 
 LANGUAGE_CODE = "{{cookiecutter.LANGUAGE_CODE}}"
@@ -140,11 +134,6 @@ USE_TZ = True
 
 TIME_ZONE = "{{cookiecutter.TIME_ZONE}}"
 {% else %}
-{% if cookiecutter.USE_L10N == "True" %}
-USE_L10N = True
-{% else %}
-USE_L10N = False
-{% endif %}
 USE_I18N = False
 
 LANGUAGE_CODE = "{{cookiecutter.LANGUAGE_CODE}}"


### PR DESCRIPTION
L10N is on by default and is deprecated in Django 4.0. Django dev will
drop the option on Django 5.0. The project setup is now more
straightforward.

closes #183