### PR TITLE
fix(templates): Add templates/ to TEMPLATES #199

### DIFF
--- a/{{cookiecutter.git_project_name}}/config/settings/base.py
+++ b/{{cookiecutter.git_project_name}}/config/settings/base.py
@@ -60,7 +60,7 @@ ROOT_URLCONF = "{{ cookiecutter.project_slug}}.urls"
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [],
+        "DIRS": [os.path.join(BASE_DIR, "templates")],
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [


### PR DESCRIPTION
Django did not recognise changes in the allauth templates.
Django could not find the allauth templates new location when added to
the Project folder.
"DIRS": [os.path.join(BASE_DIR, "templates")] added to TEMPLATES to
tell Django where to look for HTML templates.

closes #199