### PR TITLE
fix(allauth): Templates deleted if allauth=n #200

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -53,6 +53,8 @@ REMOVE_FILES = [
         compose {% endif %}',
     '{% if cookiecutter.deploy_with_docker == "n" %} \
         docker-entrypoint.sh {% endif %}',
+    '{% if cookiecutter.use_django_allauth == "n" %} \
+        templates/account {% endif %}',
 ]
 
 # Helper functions

--- a/tests/test_bake_django.py
+++ b/tests/test_bake_django.py
@@ -76,6 +76,24 @@ def test_baked_django_without_allauth_settings_ok(cookies):
     )
 
 
+def test_baked_django_with_allauth_templates_ok(cookies):
+    """Test Django allauth HTML templates have been generated."""
+    default_django = cookies.bake()
+
+    templates_path = default_django.project_path / "templates/account"
+
+    assert os.path.isdir(templates_path)
+
+
+def test_baked_django_without_allauth_templates_ok(cookies):
+    """Test Django allauth HTML templates have not been generated."""
+    non_default_django = cookies.bake(extra_context={"use_django_allauth": "n"})
+
+    templates_path = non_default_django.project_path / "templates/account"
+
+    assert not os.path.isdir(templates_path)
+
+
 def test_baked_django_with_allauth_url_ok(cookies):
     """Test Django allauth url.py file entry has been generated."""
     default_django = cookies.bake()


### PR DESCRIPTION
Selecting django-allauth=n did not remove django-allauth templates from
the project/templates folder.
templates/account now removed when selecting django-allauth=n.
Tests are written to cover this action.

closes #200