### PR TITLE
fix(Dockerfile): Add ENV's for PYTHON #204

### DIFF
--- a/{{cookiecutter.git_project_name}}/Dockerfile
+++ b/{{cookiecutter.git_project_name}}/Dockerfile
@@ -36,6 +36,8 @@ ARG USER=django
 RUN groupadd -r ${USER} && useradd --no-log-init -r -g ${USER} ${USER}
 ENV VIRTUAL_ENV_PROD=/venv_prod
 ENV PATH="$VIRTUAL_ENV_PROD/bin:$PATH"
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
 
 # Install packages needed to run your application.
 #   mime-support -- for mime types when serving static files


### PR DESCRIPTION
These ENV lost in Dockerfile updates, now added back in.
ENV PYTHONDONTWRITEBYTECODE 1
ENV PYTHONUNBUFFERED 1

closes #204