### PR TITLE
fix(project): Remove LOGIN/LOGOUT from settings #213

### DIFF
--- a/docs/source/reference/reference-project-inputs.rst
+++ b/docs/source/reference/reference-project-inputs.rst
@@ -159,23 +159,31 @@ Semantic Release.  This workflow requires a GitHub secret key, `SEM_VER`.
 Django Settings
 ---------------
 
-"ALLOWED_HOSTS": "www.example.com",
+"ALLOWED_HOSTS": "",
 
-"INTERNAL_IPS": "127.0.0.1",
+"INTERNAL_IPS": "",
 
-"LANGUAGE_CODE": "en-au",
+"LANGUAGE_CODE": "en",
 
-"LANGUAGES": "hi",
+"LANGUAGES": "en, hi",,
 
 "TIME_ZONE": "UTC",
-
-"USE_L10N": "True",
 
 "USE_I18N": "True",
 
 "SITE_ID": "1",
 
 See `Django Settings`_ for more information.
+
+Django Plugin Options
+---------------------
+
+"use_django_allauth": [ "y", "n"]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Support for multiple authentication schemes.
+
+Support for multiple strategies for account verification.
 
 Documentation
 ---------------

--- a/tests/test_bake_django.py
+++ b/tests/test_bake_django.py
@@ -50,6 +50,8 @@ def test_baked_django_with_allauth_settings_ok(cookies):
     assert (
         '                "django.template.context_processors.request",' in settings_file
     )
+    assert 'LOGIN_REDIRECT_URL = "/admin/"' in settings_file
+    assert "LOGOUT_REDIRECT_URL = '/accounts/login/'" in settings_file
     assert (
         "ACCOUNT_UNIQUE_EMAIL = True                      # Default dj-allauth"
         in settings_file
@@ -70,10 +72,16 @@ def test_baked_django_without_allauth_settings_ok(cookies):
     assert (
         '                "django.template.context_processors.request",' in settings_file
     )
+    assert 'LOGIN_REDIRECT_URL = "/admin/"' not in settings_file
+    assert "LOGOUT_REDIRECT_URL = '/accounts/login/'" not in settings_file
     assert (
         "ACCOUNT_UNIQUE_EMAIL = True                      # Default dj-allauth"
         not in settings_file
     )
+
+
+#  assert 'LOGIN_REDIRECT_URL = "/admin/"' in settings_file
+#  assert "LOGOUT_REDIRECT_URL = '/accounts/login/'" in settings_file
 
 
 def test_baked_django_with_allauth_templates_ok(cookies):

--- a/{{cookiecutter.git_project_name}}/config/settings/base.py
+++ b/{{cookiecutter.git_project_name}}/config/settings/base.py
@@ -41,8 +41,11 @@ SITE_ID = 1
 {% else %}
 SITE_ID = {{cookiecutter.SITE_ID}}
 {% endif %}
+{% if cookiecutter.use_django_allauth == "y" %}
+# LOGIN_REDIRECT_URL For new project convenience, change to your project requirements.
 LOGIN_REDIRECT_URL = "/admin/"
 LOGOUT_REDIRECT_URL = '/accounts/login/'
+{% endif %}
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",


### PR DESCRIPTION
These two settings are for django-allauth.
If use_django_allauth=n, delete these settings on project generation.

LOGIN_REDIRECT_URL = "/admin/"
LOGOUT_REDIRECT_URL = '/accounts/login/'

closes #213