### PR TITLE
feat(test): Add test DB options def=sqlite #227

### DIFF
--- a/docs/source/how-tos/how-to-quickstart.rst
+++ b/docs/source/how-tos/how-to-quickstart.rst
@@ -199,5 +199,66 @@ pushing to GitHub.  If you are unsure, see our
 :ref:`git push tutorial<create-first-git-push>` for more information.
 
 
+Default Testing Database
+------------------------
+
+By default, your Django project test DB is db.sqlite3.
+
+See config/settings/test.py and .env/.testing.
+
+.. code-block:: python
+    :caption: **config/settings/test.py**
+
+    ...
+
+    # Selects which database to use for testing, default=sqlite3 .
+    TESTING_DATABASE = env("TESTING_DATABASE")
+
+    if TESTING_DATABASE == "sqlite3":
+
+        DATABASES = {
+            "default": {
+                "ENGINE": "django.db.backends.sqlite3",
+                # "NAME": BASE_DIR / "db.sqlite3",
+            }
+        }
+
+    else:
+
+        DATABASES = {"default": env.db()}
+
+
+.. code-block:: text
+    :caption: **.env/.testing**
+
+    ...
+
+    # Testing database options: sqlite3, other.
+    # If using other, a DB_URL connection string must be supplied.
+    TESTING_DATABASE=sqlite3
+    DB_URL=""
+
+
+To select another testing database, you can:
+
+#.  Update .env/.testing variables with your preferences.
+#.  Provide ENV vars with your preferences.
+
+.. code-block:: text
+    :caption: **Option 1**
+
+    ...
+
+    # Testing database options: sqlite3, other.
+    # If using other, a DB_URL connection string must be supplied.
+    TESTING_DATABASE=other  # Change to other.
+    DB_URL=Your_connection_string_here
+
+.. code-block:: bash
+    :caption: **Option 2**
+
+    export TESTING_DATABASE=other
+    export DB_URL=Your_connection_string_here
+
 
 .. _cookiecutter: https://cookiecutter.readthedocs.io/en/1.7.2/README.html

--- a/docs/source/how-tos/how-to-quickstart.rst
+++ b/docs/source/how-tos/how-to-quickstart.rst
@@ -181,7 +181,7 @@ Install dependencies.
 
 .. include:: ../tutorials/tutorial-segment-create-env-variable.rst
 
-Test Your Project
+Run Your Project
 -----------------
 
 .. code-block:: bash

--- a/{{cookiecutter.git_project_name}}/.env/.testing
+++ b/{{cookiecutter.git_project_name}}/.env/.testing
@@ -1,5 +1,5 @@
 DJANGO_DEBUG=FALSE
-DJANGO_SECRET_KEY=""
+DJANGO_SECRET_KEY="!!!INSECURE_TESTING_SECRET!!!"
 DJANGO_MANAGEPY_MIGRATE=on
 DJANGO_SETTINGS_MODULE=config.settings.testing
 DB_ENGINE=""
@@ -8,4 +8,11 @@ DB_USER=""
 DB_PASSWORD=""
 DB_HOST=""
 DB_PORT=""
+ALLOWED_HOSTS=""
 INTERNAL_IPS=""
+
+# Testing database options: sqlite3, other.
+# If using other, a DB_URL connection string must be supplied.
+TESTING_DATABASE=sqlite3
+DB_URL=""
+

--- a/{{cookiecutter.git_project_name}}/config/settings/test.py
+++ b/{{cookiecutter.git_project_name}}/config/settings/test.py
@@ -15,8 +15,28 @@ SECRET_KEY = env("DJANGO_SECRET_KEY")
 
 DEBUG = env("DJANGO_DEBUG", default=False)
 
-ALLOWED_HOSTS = ["{{cookiecutter.ALLOWED_HOSTS}}"]
+ALLOWED_HOSTS = [""]
 
+INTERNAL_IPS = [""]
+
+
+# Selects which database to use for testing, default=sqlite3 .
+TESTING_DATABASE = env("TESTING_DATABASE")
+
+if TESTING_DATABASE == "sqlite3":
+
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.sqlite3",
+            # "NAME": BASE_DIR / "db.sqlite3",
+        }
+    }
+
+else:
+
+    DATABASES = {"default": env.db()}
+
+# Test with DEBUG off can speed up tests.
 assert not settings.DEBUG, "DEBUG mode should be off for testing."  # nosec
 
 DEFAULT_FILE_STORAGE = "inmemorystorage.InMemoryStorage"


### PR DESCRIPTION
Sometimes it is not convenient to run tests if a connection to a
PostgreSQL, MySQL or other DB is unavailable.
Local and or learning projects may not warrant a Production
grade Database.
Using an ENV to select between db.sqlite3 or a production database can
make the testing process easier.

closes #227