### PR TITLE
docs(how-to): Add changing test DB settings #239

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ Django Project Features
    and `test` environments default to using `SQLite`_, Django's bundled
    database.
 #. More advanced users can change the test environment database with an
-   environment variable to match the production environment.
+   environment variable to match the production environment. See the How-to `here`_.
 #. `Django-allauth`_ provides authentication.
 #. A `CustomUser` model, complete with tests and custom user types. See
    `How-to Custom User`_ for customisation options before your initial migration.
@@ -59,6 +59,7 @@ see our tutorial, `Create a Django-Cookiecutter Project`_.
 .. _Django-allauth: https://django-allauth.readthedocs.io/en/latest/installation.html
 .. _SQLite: https://www.sqlite.org/index.html
 .. _How-to Custom User: https://django-cookiecutter.readthedocs.io/en/latest/how-tos/how-to-custom-user.html
+.. _here: https://django-cookiecutter.readthedocs.io/en/latest/how-tos/how-to-test-env-settings.html
 .. _Create a Django-Cookiecutter Project: https://django-cookiecutter.readthedocs.io/en/latest/tutorials/tutorial-create-django-project.html
 
 Django Project Creation Options

--- a/docs/source/how-tos/how-to-test-env-settings.rst
+++ b/docs/source/how-tos/how-to-test-env-settings.rst
@@ -1,0 +1,94 @@
+.. include:: /extras.rst.txt
+.. highlight:: rst
+.. index:: how-to-test-env-settings ; Index
+
+.. _test-env-settings:
+============================
+Test Environment DB Settings
+============================
+
+By default, SQLite is used in the test environment to make it easier for
+
+#. Quick local development without the need to set up Postgress and
+#. New Django users.
+
+
+Using PostgreSQL
+----------------
+
+By default PostgreSQL is our preferred option for Production.
+
+If you wish to test using the same environment configuration as production,
+you can make changes to /.env/.testing.
+
+#. Change line 16 to `other`.
+#. Add your PostgresSQL connection string to line 17, or
+#. Create an environment variable DB_URL with your connection string,
+   See :ref:`here<create-env-var-segment>` for a tutorial about creating
+   environment variables.
+
+.. code-block:: python
+    :emphasize-lines: 14-17
+    :caption: /.env/.testing
+    :linenos:
+
+    DJANGO_DEBUG=FALSE
+    DJANGO_SECRET_KEY="!!!INSECURE_TESTING_SECRET!!!"
+    DJANGO_MANAGEPY_MIGRATE=on
+    DJANGO_SETTINGS_MODULE=config.settings.testing
+    DB_ENGINE=""
+    DB_NAME=""
+    DB_USER=""
+    DB_PASSWORD=""
+    DB_HOST=""
+    DB_PORT=""
+    ALLOWED_HOSTS=""
+    INTERNAL_IPS=""
+
+    # Testing database options: sqlite3, other.
+    # If using other, a DB_URL connection string must be supplied.
+    TESTING_DATABASE=sqlite3
+    DB_URL=""
+
+.. warning::
+
+    DB_URL can conflict with your production DB if your testing machine
+    and production machine are the same.
+
+
+Other Databases
+---------------
+
+In addition to making the changes in the `Using PostgreSQL` section above the
+following changes need to be made.
+
+Three dependency files need to be updated.
+
+#. /config/requirements/test.txt
+#. /config/requirements/staging.txt
+#. /config/requirements/production.txt
+
+With these changes.
+
+#. Line 3 and line 4 must be commented out or deleted.
+#. Add your preferred database's dependencies in these files.
+
+
+.. code-block:: python
+    :emphasize-lines: 3-4
+    :caption: Depencies to remove.
+    :linenos:
+
+    coverage==6.2
+    dj-inmemorystorage==2.1.0
+    psycopg2==2.9.3 # This version should be used in production
+    # psycopg2-binary  # This version is ok for Development and Testing
+    pytest==6.2.5
+    pytest-django==4.5.2
+    pytest-reverse==1.3.0
+    pytest-xdist==2.5.0
+    tblib==1.7.0
+    tox==3.24.5
+
+
+Follow any other instructions from your DB vendor for integration with Django.

--- a/docs/source/how-tos/index-how-to.rst
+++ b/docs/source/how-tos/index-how-to.rst
@@ -16,5 +16,6 @@ See below for a list of How-To for Django Cookiecutter.
 
    how-to-quickstart
    how-to-custom-user
+   how-to-test-env-settings
    how-to-docker-linux-cheatsheet
    how-to-contribute


### PR DESCRIPTION
Add how-to change test DB settings document.
Update how-to index.
Add link to new how-to to README.

closes #239