### PR TITLE
fix(git): Remove "" from initial commit message #250

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -154,7 +154,7 @@ def git_add_and_commit_initial():
         "git",
         "commit",
         "-m",
-        '"chore(git): Initial Commit"',
+        "chore(git): Initial Commit",
         cwd=PROJECT_DIRECTORY,
     )
 


### PR DESCRIPTION
Initial commit message is bounded by "". Remove the quotations

closes #250