### PR TITLE
fix(pre-commit): django-upgrade removed #252

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,11 +22,6 @@ repos:
       - id: pyupgrade
         args: [--py39-plus]
 
-  - repo: https://github.com/adamchainz/django-upgrade
-    rev: 1.2.0
-    hooks:
-      - id: django-upgrade
-        args: [--target-version, "4.0"]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1

--- a/{{cookiecutter.git_project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.git_project_name}}/.pre-commit-config.yaml
@@ -20,11 +20,12 @@ repos:
       - id: pyupgrade
         args: [--py39-plus]
 
-  - repo: https://github.com/adamchainz/django-upgrade
-    rev: 1.2.0
-    hooks:
-      - id: django-upgrade
-        args: [--target-version, "4.0"]
+  # Section commented out issue-252. target-version=4.0 broken
+  # - repo: https://github.com/adamchainz/django-upgrade
+  #   rev: 1.2.0
+  #   hooks:
+  #     - id: django-upgrade
+  #       args: [--target-version, "4.0"]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1


### PR DESCRIPTION
django-upgrade target version 4.0 had stopped working.

closes #252