### PR TITLE
chore(user): Improve admin create user form #272

### DIFF
--- a/{{cookiecutter.git_project_name}}/users/admin.py
+++ b/{{cookiecutter.git_project_name}}/users/admin.py
@@ -26,10 +26,10 @@ class CustomUserAdmin(UserAdmin):
     model = CustomUser
 
     fieldsets = UserAdmin.fieldsets + (
-        (
-            "User Type",
-            {"fields": ("user_type",)},
-        ),
+        ("User Type", {'fields': ('user_type',)}),
+    )
+    add_fieldsets = UserAdmin.add_fieldsets + (
+        (None, {'fields': ("email",'user_type', )}),
     )
 
     list_display = [


### PR DESCRIPTION
The CustomUser admin create form was missing some fields
to make the creation of a new user easy.

closes #272