### PR TITLE
fix(pre-comm): Add --format black to isort #264

### DIFF
--- a/{{cookiecutter.git_project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.git_project_name}}/.pre-commit-config.yaml
@@ -2,7 +2,8 @@ default_language_version:
   python: python3.10
 default_stages: [commit]
 fail_fast: true
-exclude: ".conf.py|^tests/|migrations|.git|.tox"
+exclude: ".conf.py|migrations|.git|.tox"
+# exclude: ".conf.py|^tests/|migrations|.git|.tox"
 ci:
   autofix_commit_msg: |
     chore(pre-commit): Auto fixes from pre-commit.com hooks
@@ -16,10 +17,16 @@ ci:
 
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.26.0
+    rev: v2.31.0
     hooks:
       - id: pyupgrade
         args: [--py39-plus]
+
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+        args: ["--profile", "black"]
 
   # Section commented out issue-252. target-version=4.0 broken
   # - repo: https://github.com/adamchainz/django-upgrade
@@ -29,7 +36,7 @@ repos:
   #       args: [--target-version, "4.0"]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.1.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -42,28 +49,27 @@ repos:
       - id: check-merge-conflict
 
   - repo: https://github.com/psf/black
-    rev: 21.8b0
+    rev: 22.1.0
     hooks:
       - id: black
-        # exclude:
-        args: [-l  79]
+        args: [-l  88]
 
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.0
+    rev: 1.7.2
     hooks:
       - id: bandit
-        # args: ["--ini=tox.ini"]
+        exclude: tests/
+
 
   - repo: https://github.com/pycqa/flake8
-    rev: 3.9.2
+    rev: 4.0.1
     hooks:
       - id: flake8
         additional_dependencies: [flake8-typing-imports==1.10.0]
-
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.9.3
-    hooks:
-      - id: isort
+        args: [
+              --ignore=W503,
+              --max-line-length=120,
+             ]
 
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.9.0


### PR DESCRIPTION
Black and Isort where conflicting, causing a round robin error.
Adding --format black to isort in .precommit-config solved this problem.

closes #264