### PR TITLE
fix(django): Add pyproject and version.toml #254

### DIFF
--- a/tests/test_bake_django.py
+++ b/tests/test_bake_django.py
@@ -675,6 +675,7 @@ def test_baked_django_readme_file(cookies):
 
     assert "**Django Boilerplate**" in readme_file
     assert "*A Django project with all the boilerplate*" in readme_file
+    assert '**Version = "0.1.0"**' in readme_file
 
 
 def test_baked_django_readme_with_license(cookies):

--- a/{{cookiecutter.git_project_name}}/README.rst
+++ b/{{cookiecutter.git_project_name}}/README.rst
@@ -4,6 +4,10 @@
 
 |
 
+**Version = "{{ cookiecutter.version }}"**
+
+|
+
 *{{cookiecutter.project_short_description}}*
 
 |

--- a/{{cookiecutter.git_project_name}}/pyproject.toml
+++ b/{{cookiecutter.git_project_name}}/pyproject.toml
@@ -1,0 +1,15 @@
+
+[tool.semantic_release]
+
+branch = "main"
+version_variable = "README.rst:Version,version.toml:__version__,docs/source/conf.py:__version__"
+
+build_command = ""
+remove_dist = false
+upload_to_release = false
+
+major_on_zero = false
+upload_to_pypi = false
+check_build_status = false
+
+commit_subject = ":memo: build(version): Bump to version - {version}."

--- a/{{cookiecutter.git_project_name}}/version.toml
+++ b/{{cookiecutter.git_project_name}}/version.toml
@@ -1,0 +1,3 @@
+[tool.semantic_release]
+
+__version__ = "{{ cookiecutter.version }}"


### PR DESCRIPTION
A working solution to the semantic version updates was to use pyproject
and version.toml files.  With the same config in setup.cfg it would not
work correctly.  This config works without a setup.py file in the root folder.

closes #254