### PR TITLE
fix(docs): Add Version to README #218

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,9 @@
 **Django 4.0+ Cookiecutter**
 ============================
 
-**Version 1.0 will signify the first stable Django build!**
+**Version = "0.26.1"**
+
+**Version 1.0.0 will signify the first stable Django build!**
 
 **This cookiecutter uses django-tailwind by default.  django-tailwind requires
 Node.js be installed on your development machine.**

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ description-file = README.rst
 
 [semantic_release]
 branch =  main
-version_variable = setup.py:__version__,docs/source/conf.py:__version__
+version_variable = README.rst:Version,setup.py:__version__,docs/source/conf.py:__version__
 
 major_on_zero = false
 upload_to_pypi = false


### PR DESCRIPTION
The version number in README will indicate to users, along with other
information on the page, when the Django Project becomes stable.

closes #218