### PR TITLE
fix(semver): Pin python-semantic-release@v7.28.1 #354

### DIFF
--- a/.github/workflows/semantic_release.yaml
+++ b/.github/workflows/semantic_release.yaml
@@ -23,6 +23,6 @@ jobs:
           fetch-depth: 0
 
       - name: Python Semantic Release
-        uses: relekang/python-semantic-release@master
+        uses: relekang/python-semantic-release@v7.28.1
         with:
           github_token: ${{ secrets.SEM_VER }}


### PR DESCRIPTION
Pinning to relekang/python-semantic-release@v7.28.1 fixes
actions using relekang/python-semantic-release@master from
failing.

closes #354