### PR TITLE
docs(deps): Revert to sphinx 6.2.1 #557

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-Sphinx==7.0.0
+Sphinx==6.2.1
 myst-parser==1.0.0
 furo==2023.3.27
 sphinx-copybutton==0.5.2


### PR DESCRIPTION
Some docs dependencies need Sphinx<7.0.0.  When these have been updated we can got to 7.0.0

closes #557