### PR TITLE
fix(deps): Sphinx reverted for myst-parser #566

### DIFF
--- a/{{cookiecutter.git_project_name}}/docs/requirements.txt
+++ b/{{cookiecutter.git_project_name}}/docs/requirements.txt
@@ -1,4 +1,4 @@
-Sphinx==7.0.0
+Sphinx==6.2.1
 myst-parser==1.0.0
 furo==2023.5.20
 sphinx-copybutton==0.5.2


### PR DESCRIPTION
The conflict is caused by:
The user requested Sphinx==7.0.0
myst-parser 1.0.0 depends on sphinx<7 and >=5

closes #566