### PR TITLE
chore(tox): Update python test env's #568

### DIFF
--- a/{{cookiecutter.git_project_name}}/tox.ini
+++ b/{{cookiecutter.git_project_name}}/tox.ini
@@ -2,12 +2,8 @@
 skipsdist = true
 skip_missing_interpreters = true
 envlist =
-    py39 pypy
-    py38-mypy
-    p39-docs
-    py38
-    py39
-    py3.10
+    py{311,3.12.0a7}-dj42
+    py{311,3.12.0a7}-dj{main}
 
 ; This block of commands finds and removes packaging artifacts at the end of
 ; every test run.
@@ -41,6 +37,8 @@ python =
     3.8: py38
     3.9: py39
     3.10: py3.10
+    3.11: py3.11
+
 
 [gh-actions:env]
 PLATFORM =


### PR DESCRIPTION
Tests are run against Python 3.11 and also locally 3.12.0a7.

closes #568