### PR TITLE
chore(settings): Update default Allowed hosts config #636

### DIFF
--- a/tests/test_bake_django.py
+++ b/tests/test_bake_django.py
@@ -940,6 +940,27 @@ def test_baked_django_settings_local_file_ok(cookies):
     assert (
         '"""Django local settings for django-boilerplate project."""' in settings_file
     )
+    assert '    "LOCAL_ALLOWED_HOSTS",' in settings_file
+    assert '    default=[""],' in settings_file
+    assert ')' in settings_file
+
+def test_baked_django_settings_local_file_with_ALLOWED_HOSTS_ok(cookies):
+    """Test Django MIT license file has been generated correctly."""
+    non_default_django = cookies.bake(
+        extra_context={
+            "ALLOWED_HOSTS": "example.com",
+        }
+    )
+
+    settings_path = non_default_django.project_path / "config/settings/local.py"
+    settings_file = settings_path.read_text().splitlines()
+
+    assert (
+        '"""Django local settings for django-boilerplate project."""' in settings_file
+    )
+    assert '    "LOCAL_ALLOWED_HOSTS",' in settings_file
+    assert '    default=["example.com"],' in settings_file
+    assert ')' in settings_file
 
 
 def test_baked_django_settings_production_file_ok(cookies):
@@ -955,12 +976,28 @@ def test_baked_django_settings_production_file_ok(cookies):
         '"""Django production settings for django-boilerplate project."""'
         in settings_file
     )
-    '    default=["trader-biz.au"],'
     assert '    "PROD_ALLOWED_HOSTS",' in settings_file
     assert '    default=[""],' in settings_file
     assert ')' in settings_file
 
+def test_baked_django_settings_production_file_with_ALLOWED_HOSTS_ok(cookies):
+    """Test Django MIT license file has been generated correctly."""
+    non_default_django = cookies.bake(
+        extra_context={
+            "ALLOWED_HOSTS": "example.com",
+        }
+    )
 
+    settings_path = non_default_django.project_path / "config/settings/production.py"
+    settings_file = settings_path.read_text().splitlines()
+
+    assert (
+        '"""Django production settings for django-boilerplate project."""'
+        in settings_file
+    )
+    assert '    "PROD_ALLOWED_HOSTS",' in settings_file
+    assert '    default=["example.com"],' in settings_file
+    assert ')' in settings_file
 
 def test_baked_django_settings_staging_file_ok(cookies):
     """Test Django config/settings/staging.py file has generated correctly."""
@@ -976,6 +1013,23 @@ def test_baked_django_settings_staging_file_ok(cookies):
     assert '    default=[""],' in settings_file
     assert ')' in settings_file
 
+def test_baked_django_settings_staging_file_with_ALLOWED_HOSTS_ok(cookies):
+    """Test Django MIT license file has been generated correctly."""
+    non_default_django = cookies.bake(
+        extra_context={
+            "ALLOWED_HOSTS": "example.com",
+        }
+    )
+
+    settings_path = non_default_django.project_path / "config/settings/staging.py"
+    settings_file = settings_path.read_text().splitlines()
+
+    assert (
+        '"""Django staging settings for django-boilerplate project."""' in settings_file
+    )
+    assert '    "STAGING_ALLOWED_HOSTS",' in settings_file
+    assert '    default=["example.com"],' in settings_file
+    assert ')' in settings_file
 
 def test_baked_django_settings_test_file_ok(cookies):
     """Test Django config/settings/test.py file has generated correctly."""
@@ -987,6 +1041,22 @@ def test_baked_django_settings_test_file_ok(cookies):
     assert '"""Django test settings for django-boilerplate project."""' in settings_file
     assert '    "TESTING_ALLOWED_HOSTS",' in settings_file
     assert '    default=[""],' in settings_file
+    assert ')' in settings_file
+
+def test_baked_django_settings_test_file_with_ALLOWED_HOSTS_ok(cookies):
+    """Test Django MIT license file has been generated correctly."""
+    non_default_django = cookies.bake(
+        extra_context={
+            "ALLOWED_HOSTS": "example.com",
+        }
+    )
+
+    settings_path = non_default_django.project_path / "config/settings/test.py"
+    settings_file = settings_path.read_text().splitlines()
+
+    assert '"""Django test settings for django-boilerplate project."""' in settings_file
+    assert '    "TESTING_ALLOWED_HOSTS",' in settings_file
+    assert '    default=["example.com"],' in settings_file
     assert ')' in settings_file
 
 

--- a/{{cookiecutter.git_project_name}}/config/settings/local.py
+++ b/{{cookiecutter.git_project_name}}/config/settings/local.py
@@ -18,12 +18,17 @@ env.read_env(
 )  # noqa: F405
 
 logger = logging.getLogger(__name__)
-
-
+{% if cookiecutter.ALLOWED_HOSTS == [] %}
 ALLOWED_HOSTS = env.list(
     "LOCAL_ALLOWED_HOSTS",
-    default=["local.trader-biz.au"],
+    default=["127.0.0.1"],
 )
+{% else %}
+ALLOWED_HOSTS = env.list(
+    "LOCAL_ALLOWED_HOSTS",
+    default=["{{cookiecutter.ALLOWED_HOSTS}}"],
+)
+{% endif %}
 
 DEBUG = env("LOCAL_DJANGO_DEBUG", default=False)
 
@@ -121,7 +126,7 @@ DEBUG_TOOLBAR_CONFIG = {
 
 INTERNAL_IPS = env.list(
     "LOCAL_DJANGO_INTERNAL_IPS",
-    default=[],
+    default=["{{cookiecutter.INTERNAL_IPS}}"],
 )
 
 # Override the default logger level to the django environment


### PR DESCRIPTION

Previously `ALLOWED_HOSTS` and `INTERNAL_IPS` would be configured with
the options passed in with cookiecutter.  The settings files have all
been updated to take their values either from `.env` or `ENV VARS`.
The `LOCAL` settings file has been modified to take a default
`ALLOWED_HOSTS` of `127.0.0.1` if `ALLOWED_HOSTS` is empty.  This makes
setup easy for new django users and will get them up and running
quickly.

All other settings are taking the values supplied in `ALLOWED_HOSTS` as
the default, and the primary source is either `.env` or `ENV_VARS`.

closes #636