### PR TITLE
chore(log): Add admins to settings, message to cookie #645

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -172,6 +172,22 @@ def git_configure_custom_commit_message():
         )
 
 
+def final_checks_reminders_for_users():
+
+    print(
+            "\nSUCCESS: Your {{cookiecutter.project_name}} \
+            has been generated successfully!",
+            "\nSome things to remember:"
+            "\n1. If using the email admins with errors feature, in config.settings.base",
+            "\n\ta. Review DJANGO_LOGGING_LEVEL meets your needs. ",
+            "\n\tb. Add names and emails to ADMINS. ",
+            "\n\tc. Review MANAGERS meets your needs ",
+            "\n\td. Review SERVER_EMAIL meets your needs ",
+            "\n You can find all these settings grouped together under: # Logging Settings",
+            "\n\n Thank you for using Django-Cookiecutter, I hope you enjoyed this experience."
+        )
+
+
 if __name__ == "__main__":
 
     remove_files(REMOVE_FILES)
@@ -184,3 +200,5 @@ if __name__ == "__main__":
 
         if "{{ cookiecutter.create_conventional_commits_edit_message}}" == "y":
             git_configure_custom_commit_message()
+
+    final_checks_reminders_for_users()

--- a/{{cookiecutter.git_project_name}}/config/settings/base.py
+++ b/{{cookiecutter.git_project_name}}/config/settings/base.py
@@ -43,7 +43,16 @@ ACCOUNT_USERNAME_BLACKLIST = username_blacklist
 # Logging Settings
 DJANGO_LOG_FILE = "logging/rotating.log"
 DJANGO_LOGGING_LEVEL = "WARNING"
+# Send an email to ADMINS if this logger level triggered
 DJANGO_LOGGING_MAIL_ADMINS = "CRITICAL"
+# Add list of people to receive emails on system errors.
+# Format is [("Name", "email_address@domain.com")]
+ADMINS = []
+# Can be an be any other people, typically the same as the ADMINS
+MANAGERS = ADMINS
+# Default: 'root@localhost'. Often the default will be blocked by the email
+# service provider.  Change to something like "SYSTEM@your_domain.com"
+SERVER_EMAIL = ""
 
 #Django Settings
 # LOGIN_REDIRECT_URL For new project convenience, change to your project requirements.
@@ -264,7 +273,7 @@ LOGGING = {
     },
     "loggers": {
         "": {
-            "handlers": ["console", "rotated_logs", "stdout"],
+            "handlers": ["console","mail_admins", "rotated_logs", "stdout"],
             # "level": Overridden in each config/settings file for environ
         },
         "django": {


### PR DESCRIPTION
Add the `ADMINS`, `MANAGERS` and `SERVER_EMAIL` to the base settings file.  Added some notes to help users configure these settings.

Add a reminder for the settings to be printed to the console after cookiecutter has created the new project.

closes #645