### PR TITLE
feat(admin): Add option to hide new user signups #300

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -22,6 +22,10 @@
     "n",
     "y"
   ],
+  "allow_new_user_signup": [
+    "n",
+    "y"
+  ],
   "show_env_in_templates": [
     "n",
     "y"

--- a/docs/source/reference/reference-project-inputs.rst
+++ b/docs/source/reference/reference-project-inputs.rst
@@ -104,6 +104,21 @@ The following Django Cookiecutter configuration options are grouped logically.
 
 Where options are in a list, the first item is the default setting.
 
+"allow_new_user_signup": ["n", "y"]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This setting uses django-constance and a context processor to provide context
+for use in a template to disable `new user signups`.
+
+Useage in template:
+
+.. code-block:: html
+
+    {% if ALLOW_NEW_USER_SIGNUP %}
+        show signup link
+    {% endif %}
+
+
 
 "show_env_in_templates": ["n", "y"]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/test_bake_django.py
+++ b/tests/test_bake_django.py
@@ -19,6 +19,74 @@ def test_django_bakes_ok_with_defaults(cookies):
     assert default_django.project_path.name == "django-boilerplate"
 
 
+def test_baked_with_allow_new_user_signup(cookies):
+    non_default_django = cookies.bake(
+        extra_context={"allow_new_user_signup": "y"}
+    )
+
+    context_path = (
+        non_default_django.project_path / "core/utils/context_processors.py"
+    )
+    context_file = context_path.read_text().splitlines()
+    settings_path = non_default_django.project_path / "config/settings/base.py"
+    settings_file = settings_path.read_text().splitlines()
+    requirements_path = (
+        non_default_django.project_path / "config/requirements/base.txt"
+    )
+    requirements_file = requirements_path.read_text().splitlines()
+
+    assert (
+        '    data["ALLOW_NEW_USER_SIGNUP"] = config.ALLOW_NEW_USER_SIGNUP'
+        in context_file
+    )
+    assert (
+        'CONSTANCE_BACKEND = "constance.backends.database.DatabaseBackend"'
+        in settings_file
+    )
+    assert "CONSTANCE_CONFIG = {" in settings_file
+    assert (
+        '    "ALLOW_NEW_USER_SIGNUP": (False, "Check to allow new user signups!", bool),'
+        in settings_file
+    )
+    assert "CONSTANCE_CONFIG_FIELDSETS = {" in settings_file
+    assert '    "User Settings": (' in settings_file
+    assert '        "ALLOW_NEW_USER_SIGNUP",' in settings_file
+    assert "django-constance[database]==2.8.0" in requirements_file
+
+
+def test_baked_without_allow_new_user_signup(cookies):
+    default_django = cookies.bake()
+
+    context_path = (
+        default_django.project_path / "core/utils/context_processors.py"
+    )
+    context_file = context_path.read_text().splitlines()
+    settings_path = default_django.project_path / "config/settings/base.py"
+    settings_file = settings_path.read_text().splitlines()
+    requirements_path = (
+        default_django.project_path / "config/requirements/base.txt"
+    )
+    requirements_file = requirements_path.read_text().splitlines()
+
+    assert (
+        '    data["ALLOW_NEW_USER_SIGNUP"] = config.ALLOW_NEW_USER_SIGNUP'
+        not in context_file
+    )
+    assert (
+        'CONSTANCE_BACKEND = "constance.backends.database.DatabaseBackend"'
+        not in settings_file
+    )
+    assert "CONSTANCE_CONFIG = {" not in settings_file
+    assert (
+        '    "ALLOW_NEW_USER_SIGNUP": (False, "Check to allow new user signups!", bool),'
+        not in settings_file
+    )
+    assert "CONSTANCE_CONFIG_FIELDSETS = {" not in settings_file
+    assert '    "User Settings": (' not in settings_file
+    assert '        "ALLOW_NEW_USER_SIGNUP",' not in settings_file
+    assert "django-constance[database]==2.8.0" not in requirements_file
+
+
 def test_baked_django_core_asgi_file_ok(cookies):
     """Test Django Core asgi.py file has been generated correctly."""
     default_django = cookies.bake()

--- a/{{cookiecutter.git_project_name}}/config/requirements/base.txt
+++ b/{{cookiecutter.git_project_name}}/config/requirements/base.txt
@@ -1,5 +1,5 @@
 Django==4.2.5
-django-allauth==0.49.0{% if cookiecutter.use_constance != "n" %}
+django-allauth==0.49.0{% if (cookiecutter.use_constance != "n" or cookiecutter.allow_new_user_signup != "n") %}
 django-constance[database]==2.8.0{% endif %}
 django-tailwind==3.6.0
 django-environ==0.11.2

--- a/{{cookiecutter.git_project_name}}/config/settings/base.py
+++ b/{{cookiecutter.git_project_name}}/config/settings/base.py
@@ -161,7 +161,21 @@ AUTH_PASSWORD_VALIDATORS = [
         "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",
     },
 ]
-{% if cookiecutter.use_constance != "n" %}
+{% if cookiecutter.allow_new_user_signup != "n" %}
+# Constance Configuration
+CONSTANCE_BACKEND = "constance.backends.database.DatabaseBackend"
+
+CONSTANCE_CONFIG = {
+    "ALLOW_NEW_USER_SIGNUP": (False, "Check to allow new user signups!", bool),
+}
+
+CONSTANCE_CONFIG_FIELDSETS = {
+    "User Settings": (
+        "ALLOW_NEW_USER_SIGNUP",
+    ),
+}
+
+{% elif cookiecutter.use_constance != "n" %}
 # Constance Configuration
 CONSTANCE_BACKEND = "constance.backends.database.DatabaseBackend"
 
@@ -171,6 +185,7 @@ CONSTANCE_CONFIG = {
         "Answer to the Ultimate Question of Life, The Universe, and Everything",
         int,
     ),
+
 }
 
 CONSTANCE_CONFIG_FIELDSETS = {

--- a/{{cookiecutter.git_project_name}}/core/utils/context_processors.py
+++ b/{{cookiecutter.git_project_name}}/core/utils/context_processors.py
@@ -1,8 +1,12 @@
 """Django context processors."""
 
 import environ
+{% if cookiecutter.allow_new_user_signup != "n" %}
+from constance import config
+{% endif %}
 from django.conf import settings
 
+from users.models import CustomUser
 
 env = environ.FileAwareEnv()
 
@@ -79,4 +83,9 @@ def export_vars(request) -> dict:
             else:
                 data["ENVIRONMENT"] = f"{environ}: Debug False"
     {% endif %}
+    {% if cookiecutter.allow_new_user_signup != "n" %}
+    data["ALLOW_NEW_USER_SIGNUP"] = config.ALLOW_NEW_USER_SIGNUP
+    {% endif %}
+
+
     return data


### PR DESCRIPTION
A constance setting in Admin can provide context to hide the `New User
Signup` link on the login page.

The context is added in `core.utils.context_processors.py` and can be
used in the HTML templates

```

{% if ALLOW_NEW_USER_SIGNUP %}
        show signup link
    {% endif %}

```
closes #300