### PR TITLE
chore(git): Update actions deps #744

### DIFF
--- a/.github/workflows/semantic_release.yaml
+++ b/.github/workflows/semantic_release.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.SEM_VER }}
           fetch-depth: 0

--- a/.github/workflows/test_contribution.yaml
+++ b/.github/workflows/test_contribution.yaml
@@ -22,10 +22,10 @@ jobs:
     name: Set up ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           cache: pip
 
       - name: Install dependencies

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 skipsdist = true
 skip_missing_interpreters = true
 envlist =
-    py311
+    py312
 
 [testenv:docs]
 basepython=python
@@ -13,7 +13,7 @@ commands=
 
 [gh-actions]
 python =
-    3.11: py311
+    3.12: py312
 
 [gh-actions:env]
 PLATFORM =


### PR DESCRIPTION
The github actions had deprecated checkout version.  Updated to V4. Updated python setup to V5

closes #744