### PR TITLE
chore(semver): Disable semantic release #624

### DIFF
--- a/.github/workflows/semantic_release.yaml
+++ b/.github/workflows/semantic_release.yaml
@@ -1,10 +1,10 @@
 name: Semantic Release
 
 on:
-  pull_request:
-    branches:
-      - main
-    types: [closed]
+#  pull_request:
+#    branches:
+#      - main
+#    types: [closed]
 
   workflow_dispatch:
 


### PR DESCRIPTION
Ongoing issues with this feature.  Disabled until I get time to dig a bit deeper.  The secret has the correct permissions, but there is still a permission error when the update is pushed.

closes #624