### PR TITLE
chore(auth): Update deprecated settings #758

### DIFF
--- a/{{cookiecutter.git_project_name}}/config/settings/base.py
+++ b/{{cookiecutter.git_project_name}}/config/settings/base.py
@@ -35,7 +35,8 @@ ACCOUNT_EMAIL_REQUIRED = True  # Default dj-allauth == False
 ACCOUNT_UNIQUE_EMAIL = True  # Default dj-allauth
 ACCOUNT_EMAIL_VERIFICATION = "mandatory"  # Default dj-allauth (optional)
 ACCOUNT_EMAIL_CONFIRMATION_EXPIRE_DAYS = 3  # Default dj-allauth
-ACCOUNT_LOGIN_ATTEMPTS_LIMIT = 5  # Default dj-allauth
+# deprecated ACCOUNT_LOGIN_ATTEMPTS_LIMIT = 5  # Default dj-allauth
+ACCOUNT_RATE_LIMITS = ['login_failed'] # Using  (default: "10/m/ip,5/5m/key")
 ACCOUNT_USERNAME_REQUIRED = True  # Default dj-allauth
 ACCOUNT_USERNAME_MIN_LENGTH = 3  # Default dj-allauth == 1
 ACCOUNT_USERNAME_BLACKLIST = username_blacklist


### PR DESCRIPTION
django-allauth ACCOUNT_LOGIN_ATTEMPTS_LIMIT has been deprecated for `Rate Limits`.  This PR updates this setting and uses the suggested default ACCOUNT_RATE_LIMITS = ['login_failed'] # Using  (default: "10/m/ip,5/5m/key")

closes #758